### PR TITLE
Fixed Parsing access_token Issue

### DIFF
--- a/.factorypath
+++ b/.factorypath
@@ -1,0 +1,3 @@
+<factorypath>
+    <factorypathentry kind="PLUGIN" id="org.mule.tooling.devkit.apt" enabled="true" runInBatchMode="false"/>
+</factorypath>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <devkit.studio.package.skip>false</devkit.studio.package.skip>
         <jackson.version>1.9.5</jackson.version>
         <mule.modules.utils.version>1.0</mule.modules.utils.version>
-        <restfb.version>1.6.9</restfb.version>
+        <restfb.version>1.39.0</restfb.version>
     </properties>
 
     <build>

--- a/src/main/java/org/mule/module/facebook/FacebookConnector.java
+++ b/src/main/java/org/mule/module/facebook/FacebookConnector.java
@@ -52,7 +52,7 @@ import java.util.List;
 @Connector(name = "facebook", schemaVersion = "2.0", friendlyName="Facebook", minMuleVersion="3.5", configElementName="config-with-oauth")
 public class FacebookConnector {
 
-	private static String FACEBOOK_URI = "https://graph.facebook.com/v1.0";
+	private static String FACEBOOK_URI = "https://graph.facebook.com/v2.8";
     private static String ACCESS_TOKEN_QUERY_PARAM_NAME = "access_token";
     private static JsonMapper mapper = new DefaultJsonMapper();
 

--- a/src/main/java/org/mule/module/facebook/connection/strategy/FacebookOAuthStrategy.java
+++ b/src/main/java/org/mule/module/facebook/connection/strategy/FacebookOAuthStrategy.java
@@ -11,8 +11,8 @@ import org.mule.api.annotations.param.Default;
 @OAuth2(friendlyName = "OAuth v2.0"
         , accessTokenUrl = "https://graph.facebook.com/oauth/access_token"
         , authorizationUrl = "https://graph.facebook.com/oauth/authorize"
-        , accessTokenRegex = "access_token=([^&]+?)(&|$)"
-        , expirationRegex = "expires=([^&]+?)(&|$)")
+        , accessTokenRegex = "\"access_token\":\"([^&]+?)\""
+        , expirationRegex = "\"expires_in\":([^&]+?),")
 public class FacebookOAuthStrategy {
 
     /**

--- a/src/test/java/org/mule/module/facebook/FacebookConnectorTestDriver.java
+++ b/src/test/java/org/mule/module/facebook/FacebookConnectorTestDriver.java
@@ -446,7 +446,7 @@ public class FacebookConnectorTestDriver
         {
             assertNotNull(post.getId());
             assertNotNull(post.getFrom().getName());
-            assertNotNull(post.getLikes().getCount());
+            assertNotNull(post.getLikes().getTotalCount());
         }
     }
     


### PR DESCRIPTION
Fixed issue with ‘access_token’ not being parsed correctly. Also upgraded restfb to version 1.39.0 and Graph API to 2.8.